### PR TITLE
Multiplicador de timeout en pantalla de arranque

### DIFF
--- a/firmware/firmware.asm
+++ b/firmware/firmware.asm
@@ -1157,7 +1157,7 @@ main
         ld      bc, $0f0b
 main1   call    showop
         defw    cad120
-        defw    cad121
+        defw    cad29
         defw    cad122
         defw    cad123
         defw    cad124
@@ -1222,7 +1222,7 @@ main4   call    showop
         ld      hl, quietb
         call    popupw          ; Boot timeout
         defw    cad120
-        defw    cad121
+        defw    cad29
         defw    cad122
         defw    cad123
         defw    cad124

--- a/firmware/firmware.asm
+++ b/firmware/firmware.asm
@@ -1231,8 +1231,8 @@ main4   call    showop
 main44  ld      h, active >> 8
         add     a, bitstr-3&$ff 
         ld      l, a
-        sub     keyiss&$ff		
-        jr      z, main5        ; main5
+        sub     keyiss&$ff
+        jr      z, main5
         jr      nc, main6
         call    popupw          ; quiet or crc (enabled or disabled)
         defw    cad28

--- a/firmware/firmware.asm
+++ b/firmware/firmware.asm
@@ -299,10 +299,12 @@ start2  ld      a, (hl)
         jr      nc, start1
         dec     e
       IF  recovery=0
-        ld      a, (quietb)
+        ld      a, 0
         out     ($fe), a
-        dec     a
+        ld      a, (quietb)        
+        cp      1
         jr      nz, start3
+        out     ($fe), a
         ld      h, l
         ld      d, $20
         call    window
@@ -436,11 +438,17 @@ star13  ld      de, $cfff
 star14  inc     b
         outi
         bit     4, h              ; compruebo si la direccion es D000 (final)
-        jr      z, star14         ; repito si no lo es
-star15  ld      d, 4
-        pop     af
+        jr      z, star14         ; repito si no lo es	
+star15  ld      d, 4              ; temporizador general (1-2 seg en 1X)        
+		call    chktmo    ; aplicamos multiplicador
+start25 pop     af
         jr      nz, star16
-        ld      d, 16
+        ld      d, 16             ; temporizador inicial (2-3 seg en 1X)
+        call    chktmo            ; aplicamos multiplicador
+        ld      a, d
+        cp      33
+        jr      c, star16
+        ld      d, 32             ; timeout inicial maximo (7-8 segundos)
 star16  djnz    star18
         dec     de
         ld      a, d
@@ -1148,12 +1156,16 @@ main
         ld      iy, quietb
         ld      bc, $0f0b
 main1   call    showop
-        defw    cad28
-        defw    cad29
+        defw    cad120
+        defw    cad121
+        defw    cad122
+        defw    cad123
+        defw    cad124
         defw    $ffff
-        ld      a, iyl
-        rrca
-        jr      c, main1
+main1b  call    showop
+        defw    cad28
+        defw    cad29		
+        defw    $ffff
 main2   call    showop
         defw    cad30
         defw    cad31
@@ -1201,14 +1213,26 @@ main4   call    showop
         defw    cad19
         defw    cad116
         jr      c, main9
-        ld      (menuop+1), a
-        cp      4
-        ld      h, active >> 8
+        ld      (menuop+1), a		
+        cp      4        
         jr      c, main8        ; c->tests, nc->options
-        add     a, bitstr-3&$ff
+        ld      e, a
+        add     hl, de
+        jr      nz, main44		
+        ld      hl, quietb
+        call    popupw          ; Boot timeout
+        defw    cad120
+        defw    cad121
+        defw    cad122
+        defw    cad123
+        defw    cad124
+        defw    $ffff
+        ret
+main44  ld      h, active >> 8
+        add     a, bitstr-3&$ff 
         ld      l, a
-        sub     keyiss&$ff
-        jr      z, main5
+        sub     keyiss&$ff		
+        jr      z, main5        ; main5
         jr      nc, main6
         call    popupw          ; quiet or crc (enabled or disabled)
         defw    cad28
@@ -3755,6 +3779,20 @@ combo9  dec     a               ; $1d
 comboa  ld      a, h
         pop     de
         pop     hl
+        ret
+		
+; --------------------------------------
+; Bitshift left 'D' according to timeout
+; --------------------------------------
+chktmo  push    af
+        ld      a, (quietb)
+        cp      2
+        jr      c, chk2
+        dec     a
+chk1    sla     d
+        dec     a
+        jr      nz, chk1
+chk2    pop     af
         ret
 
 ; -------------------------------------

--- a/firmware/strings.asm
+++ b/firmware/strings.asm
@@ -174,7 +174,6 @@ cad34   defb    'Move Down  a', 0
 cad35   defb    'Rename', 0
 cad36   defb    'Delete', 0
 cad120   defb    'Timeout 1X', 0
-cad121   defb    'Enabled', 0
 cad122   defb    'Timeout 2X', 0
 cad123   defb    'Timeout 4X', 0
 cad124   defb    'Timeout 8X', 0

--- a/firmware/strings.asm
+++ b/firmware/strings.asm
@@ -4,7 +4,7 @@ cad1    defb    'http://zxuno.speccy.org', 0
       ELSE
 cad1    defb    'http://zxdos.forofpga.es', 0
       ENDIF
-        defb    'ZX-Uno BIOS v0.80', 0
+        defb    'ZX-Uno BIOS v0.81', 0
         defb    'Copyleft ', 127, ' 2020 ZX-Uno Team', 0
         defb    'Processor: Z80 3.5MHz', 0
         defb    'Memory:    '
@@ -41,7 +41,7 @@ cad8    defb    $10, '                         ', $10, '              ', $10, 0
 cad9    defb    $14, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11
         defb    $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $18, $11
         defb    $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $15, 0
-        defb    '   BIOS v0.80    ', $7f, '2020 ZX-Uno Team', 0
+        defb    '   BIOS v0.81    ', $7f, '2020 ZX-Uno Team', 0
       ELSE
         defb    'Press <Edit> to Setup',0
         defb    '      <Break> Boot Menu', 0
@@ -72,7 +72,7 @@ cad8    defb    $10, '                              ', $10, 0
 cad9    defb    $14, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11
         defb    $11, $11, $11, $11
         defb    $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $15, 0
-        defb    ' BIOS v0.80 ', $7f, '2020 ZX1 Team', 0
+        defb    ' BIOS v0.81 ', $7f, '2020 ZX1 Team', 0
         defs    $66
       ENDIF
 cad10   defb    'Hardware tests', 0
@@ -173,6 +173,11 @@ cad33   defb    'Set Active', 0
 cad34   defb    'Move Down  a', 0
 cad35   defb    'Rename', 0
 cad36   defb    'Delete', 0
+cad120   defb    'Timeout 1X', 0
+cad121   defb    'Enabled', 0
+cad122   defb    'Timeout 2X', 0
+cad123   defb    'Timeout 4X', 0
+cad124   defb    'Timeout 8X', 0
       IF  vertical=0
         defb    ' ', $12, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11
         defb    ' Rename ', $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $11, $13, 0


### PR DESCRIPTION
Desde el menu principal, en Quiet boot, ahora es posible aumentar el tiempo de espera al mostrarse la pantalla inicial de arranque.